### PR TITLE
Fix build error by excluding `__pycache__`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ log
 # Ignore everything in src except a .gitkeep file
 src/*
 !src/.gitkeep
+
+# Ignore Python bytecode cache directories
+__pycache__/

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         (os.path.join('share', package_name, 'meshes_l'), glob('meshes_l/**')),
         (os.path.join('share', package_name, 'meshes_r'), glob('meshes_r/**')),
         (os.path.join('share', package_name, 'rviz'), glob('rviz/*.rviz')),
-        (os.path.join('share', package_name, 'scripts'), glob('scripts/**'))
+        (os.path.join('share', package_name, 'scripts'), glob('scripts/*.py'))
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
### Summary

Hi! This PR makes one small changes to fix a build issue I encountered.

### Problem

When I tried to build the package using `colcon build`, I got the following error:

```shell
--- stderr: rohand_urdf_ros2
error: can't copy '.../rohand_urdf_ros2/scripts/__pycache__': doesn't exist or not a regular file
---
Failed   <<< rohand_urdf_ros2 [1.05s, exited with code 1]
```



It looks like the `setup.py` file was including everything in the `scripts/` directory using:

```python
glob('scripts/**')
```

This also matched the `__pycache__` directory, which is not a regular file. As a result, the installation step failed during the build process.

```shell
>scripts$ tree 
.
├── FingerMathURDF.py
├── __init__.py
├── __pycache__
│   ├── FingerMathURDF.cpython-310.pyc
│   ├── __init__.cpython-310.pyc
│   ├── rohand_joint_state_gui.cpython-310.pyc
│   └── rohand_urdf.cpython-310.pyc
├── rohand_joint_state_gui.py
└── rohand_urdf.py
```

###  Fix

**Updated `setup.py`**

- Replaced `glob('scripts/**')` with `glob('scripts/*.py')` to only include actual script files and avoid packaging `__pycache__`.

- This limits the installed files to just `.py` scripts, and avoids the `__pycache__` folder entirely

  

**Minor `.gitignore` Cleanup**

- Added this line:

  ```bash
  # Ignore Python bytecode cache directories
  __pycache__/
  ```

- While not directly related to the error, it helps keep the repo clean and avoids committing compiled bytecode folders.



After applying the `setup.py` fix, the build process completes without errors.
The `.gitignore` update is a small improvement for long-term cleanliness =D

